### PR TITLE
Fix JobApplication usage

### DIFF
--- a/src/job_application.py
+++ b/src/job_application.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, field
+from typing import Dict
+
+from src.job import Job
+
+@dataclass
+class JobApplication:
+    """Represents a single job application entry."""
+
+    job: Job
+    application: Dict = field(default_factory=dict)
+    resume_path: str = ""
+    cover_letter_path: str = ""

--- a/src/job_application_saver.py
+++ b/src/job_application_saver.py
@@ -6,8 +6,8 @@ import shutil
 from dataclasses import asdict
 
 from config import JOB_APPLICATIONS_DIR
-from job import Job
-from job_application import JobApplication
+from src.job import Job
+from src.job_application import JobApplication
 
 # Base directory where all applications will be saved
 BASE_DIR = JOB_APPLICATIONS_DIR
@@ -23,8 +23,8 @@ class ApplicationSaver:
     def create_application_directory(self):
         job = self.job_application.job
 
-        # Create a unique directory name using the application ID and company name
-        dir_name = f"{job.id} - {job.company} {job.title}"
+        # Create a unique directory name using the company and role
+        dir_name = f"{job.company} - {job.role}"
         dir_path = os.path.join(BASE_DIR, dir_name)
 
         # Create the directory if it doesn't exist


### PR DESCRIPTION
## Summary
- create `JobApplication` dataclass
- fix imports in `job_application_saver`
- use job role when creating application directory

## Testing
- `python -m py_compile src/job_application.py src/job_application_saver.py src/job.py src/jobContext.py src/libs/resume_and_cover_builder/module_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849916e0708832cb92a4afa4c09fd2d