### PR TITLE
Switch default LLM to Ollama Mistral

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 # In this file, you can set the configurations of the app.
 
-from src.utils.constants import DEBUG, ERROR, LLM_MODEL, OPENAI
+from src.utils.constants import DEBUG, ERROR, LLM_MODEL
 
 #config related to logging must have prefix LOG_
 LOG_LEVEL = 'ERROR'
@@ -16,7 +16,7 @@ JOB_SUITABILITY_SCORE = 7
 JOB_MAX_APPLICATIONS = 5
 JOB_MIN_APPLICATIONS = 1
 
-LLM_MODEL_TYPE = 'openai'
-LLM_MODEL = 'gpt-4o-mini'
+LLM_MODEL_TYPE = 'ollama'
+LLM_MODEL = 'mistral'
 # Only required for OLLAMA models
 LLM_API_URL = ''

--- a/src/libs/resume_and_cover_builder/llm/llm_generate_cover_letter_from_job.py
+++ b/src/libs/resume_and_cover_builder/llm/llm_generate_cover_letter_from_job.py
@@ -7,7 +7,8 @@ import textwrap
 from ..utils import LoggerChatModel
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from langchain_ollama import ChatOllama
+from langchain_community.embeddings import OllamaEmbeddings
 from pathlib import Path
 from dotenv import load_dotenv
 from requests.exceptions import HTTPError as HTTPStatusError
@@ -25,9 +26,9 @@ log_path = Path(log_folder).resolve()
 logger.add(log_path / "gpt_cover_letter_job_descr.log", rotation="1 day", compression="zip", retention="7 days", level="DEBUG")
 
 class LLMCoverLetterJobDescription:
-    def __init__(self, openai_api_key, strings):
-        self.llm_cheap = LoggerChatModel(ChatOpenAI(model_name="gpt-4o-mini", openai_api_key=openai_api_key, temperature=0.4))
-        self.llm_embeddings = OpenAIEmbeddings(openai_api_key=openai_api_key)
+    def __init__(self, ollama_api_url, strings):
+        self.llm_cheap = LoggerChatModel(ChatOllama(model="mistral", base_url=ollama_api_url))
+        self.llm_embeddings = OllamaEmbeddings(base_url=ollama_api_url)
         self.strings = strings
 
     @staticmethod

--- a/src/libs/resume_and_cover_builder/llm/llm_generate_resume.py
+++ b/src/libs/resume_and_cover_builder/llm/llm_generate_resume.py
@@ -7,7 +7,7 @@ import textwrap
 from src.libs.resume_and_cover_builder.utils import LoggerChatModel
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI
+from langchain_ollama import ChatOllama
 from dotenv import load_dotenv
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from loguru import logger
@@ -24,11 +24,9 @@ log_path = Path(log_folder).resolve()
 logger.add(log_path / "gpt_resume.log", rotation="1 day", compression="zip", retention="7 days", level="DEBUG")
 
 class LLMResumer:
-    def __init__(self, openai_api_key, strings):
+    def __init__(self, ollama_api_url, strings):
         self.llm_cheap = LoggerChatModel(
-            ChatOpenAI(
-                model_name="gpt-4o-mini", openai_api_key=openai_api_key, temperature=0.4
-            )
+            ChatOllama(model="mistral", base_url=ollama_api_url)
         )
         self.strings = strings
 

--- a/src/libs/resume_and_cover_builder/llm/llm_generate_resume_from_job.py
+++ b/src/libs/resume_and_cover_builder/llm/llm_generate_resume_from_job.py
@@ -7,7 +7,7 @@ from src.libs.resume_and_cover_builder.llm.llm_generate_resume import LLMResumer
 from src.libs.resume_and_cover_builder.utils import LoggerChatModel
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI
+from langchain_ollama import ChatOllama
 from dotenv import load_dotenv
 from loguru import logger
 from pathlib import Path
@@ -22,8 +22,8 @@ log_path = Path(log_folder).resolve()
 logger.add(log_path / "gpt_resum_job_descr.log", rotation="1 day", compression="zip", retention="7 days", level="DEBUG")
 
 class LLMResumeJobDescription(LLMResumer):
-    def __init__(self, openai_api_key, strings):
-        super().__init__(openai_api_key, strings)
+    def __init__(self, ollama_api_url, strings):
+        super().__init__(ollama_api_url, strings)
 
     def set_job_description_from_text(self, job_description_text) -> None:
         """

--- a/src/libs/resume_and_cover_builder/llm/llm_job_parser.py
+++ b/src/libs/resume_and_cover_builder/llm/llm_job_parser.py
@@ -6,7 +6,7 @@ import re  # For email validation
 from src.libs.resume_and_cover_builder.utils import LoggerChatModel
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
-from langchain_openai import ChatOpenAI
+from langchain_ollama import ChatOllama
 from dotenv import load_dotenv
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from loguru import logger
@@ -14,12 +14,11 @@ from pathlib import Path
 from langchain_core.prompt_values import StringPromptValue
 from langchain_core.runnables import RunnablePassthrough
 from langchain_text_splitters import TokenTextSplitter
-from langchain_community.embeddings import OpenAIEmbeddings
+from langchain_community.embeddings import OllamaEmbeddings
 from langchain_community.vectorstores import FAISS
 from lib_resume_builder_AIHawk.config import global_config
 from langchain_community.document_loaders import TextLoader
 from requests.exceptions import HTTPError as HTTPStatusError  # HTTP error handling
-import openai
 
 # Load environment variables from the .env file
 load_dotenv()
@@ -33,13 +32,11 @@ logger.add(log_path / "gpt_resume.log", rotation="1 day", compression="zip", ret
 
 
 class LLMParser:
-    def __init__(self, openai_api_key):
+    def __init__(self, ollama_api_url):
         self.llm = LoggerChatModel(
-            ChatOpenAI(
-                model_name="gpt-4o-mini", openai_api_key=openai_api_key, temperature=0.4
-            )
+            ChatOllama(model="mistral", base_url=ollama_api_url)
         )
-        self.llm_embeddings = OpenAIEmbeddings(openai_api_key=openai_api_key)  # Initialize embeddings
+        self.llm_embeddings = OllamaEmbeddings(base_url=ollama_api_url)
         self.vectorstore = None  # Will be initialized after document loading
 
     @staticmethod

--- a/src/libs/resume_and_cover_builder/resume_facade.py
+++ b/src/libs/resume_and_cover_builder/resume_facade.py
@@ -18,7 +18,7 @@ class ResumeFacade:
         """
         Initialize the FacadeManager with the given API key, style manager, resume generator, resume object, and log path.
         Args:
-            api_key (str): The OpenAI API key to be used for generating text.
+            api_key (str): The Ollama API URL to be used for generating text.
             style_manager (StyleManager): The StyleManager instance to manage the styles.
             resume_generator (ResumeGenerator): The ResumeGenerator instance to generate resumes and cover letters.
             resume_object (str): The resume object to be used for generating resumes and cover letters.
@@ -73,7 +73,7 @@ class ResumeFacade:
         self.driver.implicitly_wait(10)
         body_element = self.driver.find_element("tag name", "body")
         body_element = body_element.get_attribute("outerHTML")
-        self.llm_job_parser = LLMParser(openai_api_key=global_config.API_KEY)
+        self.llm_job_parser = LLMParser(ollama_api_url=global_config.API_KEY)
         self.llm_job_parser.set_body_html(body_element)
 
         self.job = Job()


### PR DESCRIPTION
## Summary
- use `ollama` and `mistral` as the default LLM configuration
- update resume builder modules to use `ChatOllama`
- update logger utilities for Ollama

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684999b9e7a8832c8288b5a74948765b